### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x' 
       - name: Run unit tests of report reprocessing

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
 
     - name: Use Node.js
       if: ${{ inputs.diff-links-enabled == 'true'}}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20.x' 
     - shell: bash

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "glob" : "11.0.3"
   },
   "devDependencies": {
-    "mocha": "11.7.1"
+    "mocha": "11.7.3"
   }
 }


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mocha from 11.7.1 to 11.7.3](https://github.com/javiertuya/junit-report-action/pull/18)
- [Bump actions/setup-node from 4 to 5](https://github.com/javiertuya/junit-report-action/pull/17)
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/junit-report-action/pull/16)