### PR TITLE
Update Node setup from 20.x to 24.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x' 
+          node-version: '24.x' 
       - name: Run unit tests of report reprocessing
         run: |
           mkdir actual

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
       if: ${{ inputs.diff-links-enabled == 'true'}}
       uses: actions/setup-node@v6
       with:
-        node-version: '20.x' 
+        node-version: '24.x' 
     - shell: bash
       if: ${{ inputs.diff-links-enabled == 'true'}}
       run: |


### PR DESCRIPTION
Node.js 20 sale de soporte activo pronto; **24** es la LTS actual.

Se actualiza `node-version` en:
- `action.yml` (runtime de la acción para los consumidores)
- `.github/workflows/test.yml` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)